### PR TITLE
Improve game data flow and charts

### DIFF
--- a/frontend/src/app/game/game/game.component.ts
+++ b/frontend/src/app/game/game/game.component.ts
@@ -30,10 +30,11 @@ export class GameComponent {
 
     // send current game result into outro
     gameService.gameState$.pipe(
-      map(state => state.stats),
-      map(stats => ({
-        dead: stats.deaths.total,
-        cost: stats.costs.total,
+      filter(states => states.length > 0),
+      map(states => states[states.length - 1]),
+      map(state => ({
+        dead: state.stats.deaths.total,
+        cost: state.stats.costs.total,
       })),
       untilDestroyed(this),
     ).subscribe(

--- a/frontend/src/app/game/graphs/graphs.component.html
+++ b/frontend/src/app/game/graphs/graphs.component.html
@@ -29,7 +29,8 @@
         *ngIf="content.multiLineData$"
         [mitigationNodes]="mitigationNodes"
         [multiLineTick$]="content.multiLineData$"
-        [scopeFormControl]="scopeFormControl">
+        [scopeFormControl]="scopeFormControl"
+        [customOptions]="content.customOptions">
       </cvd-line-graph>
     </div>
   </ng-container>

--- a/frontend/src/app/game/graphs/graphs.component.ts
+++ b/frontend/src/app/game/graphs/graphs.component.ts
@@ -2,9 +2,9 @@ import {AfterViewInit, Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {UntilDestroy, untilDestroyed} from '@ngneat/until-destroy';
 import {ChartOptions} from 'chart.js';
+import {last} from 'lodash';
 import {Observable, Subscription} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {SvgIconName} from 'src/app/shared/icon/icon.registry';
+import {filter, map} from 'rxjs/operators';
 import {formatNumber} from '../../utils/format';
 import {GameService} from '../game.service';
 import {MitigationsService} from '../mitigations-control/mitigations.service';
@@ -31,11 +31,21 @@ export class GraphsComponent implements AfterViewInit {
       }],
     },
   };
+  immunizedCustomOptions: ChartOptions = {
+    legend: {
+      display: true,
+    },
+    scales: {
+      yAxes: [{
+        stacked: true,
+      }],
+    },
+  };
 
-  infectedToday$: Observable<ChartValue> | undefined;
-  costTotal$: Observable<ChartValue> | undefined;
-  deathToday$: Observable<ChartValue> | undefined;
-  immunizedChart$: Observable<ChartValue[]> | undefined;
+  infectedToday$: Observable<ChartValue[]> | undefined;
+  costTotal$: Observable<ChartValue[]> | undefined;
+  deathToday$: Observable<ChartValue[]> | undefined;
+  immunizedChart$: Observable<ChartValue[][]> | undefined;
   immunized$: Observable<number> | undefined;
 
   mitigations$: Subscription | undefined;
@@ -43,98 +53,103 @@ export class GraphsComponent implements AfterViewInit {
   templateData: any | undefined;
   activeTab = 0;
 
-  private currentMitigation: string | undefined = undefined;
+  private currentMitigation: string | undefined;
 
-// TODO Add hysteresis maybe?
-  private costTotalThresholds(value: number): NodeState {
-    if (value < 10_000_000_000) return 'ok';
-    if (value >= 10_000_000_000 && value < 50_000_000_000) return 'warn';
-    if (value >= 50_000_000_000) return 'critical';
+  private costDailyThresholds(value: number): NodeState {
+    if (value < 500_000_000) return 'ok';
+    if (value < 2_000_000_000) return 'warn';
+    return 'critical';
   }
 
   private deathThresholds(value: number): NodeState {
     if (value < 50) return 'ok';
-    if (value >= 50 && value < 150) return 'warn';
-    if (value >= 150) return 'critical';
+    if (value < 150) return 'warn';
+    return 'critical';
   }
 
   private infectedThresholds(value: number): NodeState {
     if (value < 5_000) return 'ok';
-    if (value >= 5_000 && value < 15_000) return 'warn';
-    if (value >= 15_000) return 'critical';
+    if (value < 15_000) return 'warn';
+    return 'critical';
   }
 
   constructor(
     public gameService: GameService,
     private mitigationsService: MitigationsService,
   ) {
-    this.resetGraphsData();
-
     this.scopeFormControl.valueChanges.pipe(
       untilDestroyed(this),
     ).subscribe(
       newVal => this.scopeFormControl.setValue(newVal, {emitEvent: false}),
     );
 
-    this.gameService.resetSubjects$.pipe(
+    const data$ = this.gameService.gameState$;
+
+    this.mitigations$ = data$.pipe(
       untilDestroyed(this),
-    ).subscribe(_ => this.resetGraphsData());
-  }
-
-  resetGraphsData() {
-    if (this.mitigations$) this.mitigations$?.unsubscribe();
-
-    this.mitigations$ = this.gameService.gameState$.subscribe(_ => {
-      this.mitigationNodes.push(
-        this.currentMitigation ? this.currentMitigation : undefined,
-      );
-
-      if (this.currentMitigation) this.currentMitigation = undefined;
+      map(d => d.length),
+    ).subscribe(length => {
+      this.mitigationNodes[length - 1] = this.currentMitigation;
+      this.currentMitigation = undefined;
     });
 
-    this.infectedToday$ = this.gameService.gameState$.pipe(map(gameState => ({
-      label: gameState.date,
-      value: gameState.stats.detectedInfections.today,
-      tooltipLabel: (value: number) => `Nově nakažení: ${formatNumber(value)}`,
-      state: this.infectedThresholds(gameState.stats.detectedInfections.today),
-    })));
-
-    this.costTotal$ = this.gameService.gameState$.pipe(map(gameState => ({
-      label: gameState.date,
-      value: gameState.stats.costs.total,
-      tooltipLabel: (value: number) => `Celkové náklady: ${formatNumber(value, true, true)}`,
-      state: this.costTotalThresholds(gameState.stats.costs.total),
-    })));
-
-    this.deathToday$ = this.gameService.gameState$.pipe(map(gameState => ({
-      label: gameState.date,
-      value: gameState.stats.deaths.today,
-      tooltipLabel: (value: number) => `Nově zemřelí: ${formatNumber(value)}`,
-      state: this.deathThresholds(gameState.stats.deaths.today),
-    })));
-
-    this.immunizedChart$ = this.gameService.gameState$.pipe(map(gs => ([
-      {
+    this.infectedToday$ = data$.pipe(
+      map(gameStates => gameStates.map(gs => ({
         label: gs.date,
-        value: Math.round(gs.sirState.resistant + gs.stats.vaccinationRate * gs.sirState.suspectible),
-        tooltipLabel: (value: number) => `Imunizováni: ${formatNumber(value)}`,
-      },
-      {
+        value: gs.stats.detectedInfections.today,
+        tooltipLabel: (value: number) => `Nově nakažení: ${formatNumber(value)}`,
+        state: this.infectedThresholds(gs.stats.detectedInfections.today),
+      }))),
+    );
+
+    this.costTotal$ = data$.pipe(
+      map(gameStates => gameStates.map(gs => ({
         label: gs.date,
-        value: gs.stats.vaccinationRate * Math.round(gs.sirState.suspectible),
-        tooltipLabel: (value: number) => `Vakcinovaní: ${formatNumber(value)}`,
-        datasetOptions: {
-          backgroundColor: `${colors.critical}33`,
-          borderColor: `${colors.warn}`,
+        value: gs.stats.costs.total,
+        tooltipLabel: (value: number) => `Celkové náklady: ${formatNumber(value, true, true)}`,
+        state: this.costDailyThresholds(gs.stats.costs.today),
+      }))),
+    );
+
+    this.deathToday$ = data$.pipe(
+      map(gameStates => gameStates.map(gs => ({
+        label: gs.date,
+        value: gs.stats.deaths.today,
+        tooltipLabel: (value: number) => `Nově zemřelí: ${formatNumber(value)}`,
+        state: this.deathThresholds(gs.stats.deaths.today),
+      }))),
+    );
+
+    this.immunizedChart$ = data$.pipe(
+      map(gameStates => gameStates.map(gs => ([
+        {
+          label: gs.date,
+          value: Math.round(gs.stats.vaccinationRate * gs.sirState.suspectible),
+          tooltipLabel: (value: number) => `Očkovaní: ${formatNumber(value)}`,
+          datasetOptions: {
+            backgroundColor: `${colors.critical}33`,
+            borderColor: `${colors.warn}`,
+            label: 'Očkovaní',
+            fill: 'origin',
+          },
+          color: colors.warn,
         },
-        color: colors.warn,
-      },
-    ])));
+        {
+          label: gs.date,
+          value: Math.round(gs.sirState.resistant),
+          tooltipLabel: (value: number) => `Imunní po nemoci: ${formatNumber(value)}`,
+          datasetOptions: {
+            label: 'Imunní po nemoci',
+            fill: '-1',
+          },
+        },
+      ]))),
+    );
 
-    this.immunized$ = this.gameService.gameState$.pipe(
-      map(gameState => Math.round(gameState.sirState.resistant
-        + gameState.stats.vaccinationRate * gameState.sirState.suspectible),
-      ),
+    this.immunized$ = this.immunizedChart$.pipe(
+      filter(states => states.length > 0),
+      map(states => states[states.length - 1]),
+      map(state => state[0].value + state[1].value),
     );
 
     this.activeTab = 0;
@@ -142,49 +157,57 @@ export class GraphsComponent implements AfterViewInit {
     this.templateData = [
       {
         label: 'Nově nakažení',
-        icon: 'virus' as SvgIconName,
-        headerData$: this.infectedToday$.pipe(map(gs => gs.value)),
-        data$: this.infectedToday$ as unknown as Observable<ChartValue>,
+        icon: 'virus',
+        headerData$: this.infectedToday$.pipe(map(gs => last(gs)?.value)),
+        data$: this.infectedToday$,
         customOptions: null,
         pipe: [false, false],
       },
       {
         label: 'Nově zemřelí',
-        icon: 'skull' as SvgIconName,
-        headerData$: this.deathToday$.pipe(map(gs => gs.value)),
-        data$: this.deathToday$ as unknown as Observable<ChartValue>,
+        icon: 'skull',
+        headerData$: this.deathToday$.pipe(map(gs => last(gs)?.value)),
+        data$: this.deathToday$,
         customOptions: null,
         pipe: [false, false],
       },
       {
         label: 'Celkové náklady',
-        icon: 'money' as SvgIconName,
-        headerData$: this.costTotal$.pipe(map(gs => gs.value)),
-        data$: this.costTotal$ as unknown as Observable<ChartValue>,
+        icon: 'money',
+        headerData$: this.costTotal$.pipe(map(gs => last(gs)?.value)),
+        data$: this.costTotal$,
         customOptions: this.costTotalCustomOptions,
         pipe: [true, true],
       },
       {
         label: 'Imunní',
-        icon: 'hospital' as SvgIconName,
+        icon: 'hospital',
         headerData$: this.immunized$,
-        multiLineData$: this.immunizedChart$ as Observable<ChartValue[]>,
-        customOptions: null,
+        multiLineData$: this.immunizedChart$,
+        customOptions: this.immunizedCustomOptions,
         pipe: [false, false],
       },
     ];
   }
 
   ngAfterViewInit() {
-    this.gameService.reset$.pipe(untilDestroyed(this)).subscribe(() => this.currentMitigation = undefined);
+    this.gameService.reset$.pipe(
+      untilDestroyed(this),
+    ).subscribe(() => {
+      this.currentMitigation = undefined;
+      this.mitigationNodes = [];
+    });
 
+    // TODO connect to change-only mitigation structure
+    // and make mitigationNodes a dictionary of dates
     for (const mitigation of Object.keys(MitigationsService.mitigationsI18n)) {
       this.mitigationsService.formGroup.get(mitigation)?.valueChanges.pipe(
         untilDestroyed(this),
       ).subscribe((value: any) => {
-        // TODO add multiple mitigations at a same time
-        this.currentMitigation = this.mitigationsService.getLabel(
+        const label = this.mitigationsService.getLabel(
           mitigation as keyof typeof MitigationsService.mitigationsI18n, value);
+        if (this.currentMitigation) this.currentMitigation += '\n' + label;
+        else this.currentMitigation = label;
       });
     }
   }

--- a/frontend/src/app/game/status-display/status-display.component.ts
+++ b/frontend/src/app/game/status-display/status-display.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {get, PropertyPath} from 'lodash';
 import {combineLatest} from 'rxjs';
-import {distinctUntilChanged, map, shareReplay} from 'rxjs/operators';
+import {distinctUntilChanged, filter, map, shareReplay} from 'rxjs/operators';
 import {Stats} from '../../services/simulation';
 import {GameService} from '../game.service';
 
@@ -11,14 +11,18 @@ import {GameService} from '../game.service';
   styleUrls: ['./status-display.component.scss'],
 })
 export class StatusDisplayComponent {
+  lastState$ = this.gameService.gameState$.pipe(
+    filter(states => states.length > 0),
+    map(states => states[states.length - 1]),
+  );
 
-  private stats$ = this.gameService.gameState$.pipe(
+  private stats$ = this.lastState$.pipe(
     map(state => state.stats),
     distinctUntilChanged(),
     shareReplay(1),
   );
 
-  private sirState$ = this.gameService.gameState$.pipe(
+  private sirState$ = this.lastState$.pipe(
     map(state => state.sirState),
     distinctUntilChanged(),
     shareReplay(1),


### PR DESCRIPTION
- stream complete data (state array) from game service
- byproduct: fix disconnected subscribers after game restart
- buffer the last state array for late subscribers
- use data incrementally (new items in the array) in charts
- display immunity chart as stacked with legend
