### PR TITLE
Add help tooltip component

### DIFF
--- a/frontend/src/app/game/events-layout/events-layout.component.ts
+++ b/frontend/src/app/game/events-layout/events-layout.component.ts
@@ -9,7 +9,7 @@ import {inOutAnimation} from 'src/app/utils/animations';
   selector: 'cvd-events-layout',
   templateUrl: './events-layout.component.html',
   styleUrls: ['./events-layout.component.scss'],
-  animations: [inOutAnimation],
+  animations: [inOutAnimation()],
 })
 export class EventsLayoutComponent {
   constructor(public gameService: GameService) {

--- a/frontend/src/app/game/game/game.component.scss
+++ b/frontend/src/app/game/game/game.component.scss
@@ -13,9 +13,9 @@
 
   &.is-event-active {
     ::ng-deep {
-      cvd-line-graph,
-      cvd-status-display,
-      cvd-mitigations-control {
+      cvd-line-graph > cvd-col,
+      cvd-status-display > cvd-row,
+      cvd-mitigations-control > cvd-col {
         opacity: 0.8;
       }
     }

--- a/frontend/src/app/game/game/game.component.ts
+++ b/frontend/src/app/game/game/game.component.ts
@@ -13,7 +13,7 @@ type GameState = 'intro' | 'game' | 'outro';
   selector: 'cvd-game',
   templateUrl: './game.component.html',
   styleUrls: ['./game.component.scss'],
-  animations: [inOutAnimation],
+  animations: [inOutAnimation()],
 })
 export class GameComponent {
 

--- a/frontend/src/app/game/graphs/graphs.component.html
+++ b/frontend/src/app/game/graphs/graphs.component.html
@@ -12,7 +12,9 @@
   </div>
 
   <ng-container *ngFor="let content of templateData; let index = index">
-    <div *ngIf="activeTab === index">
+    <div
+      class="tab-content"
+      *ngIf="activeTab === index">
       <h3>
         {{ content.label }}
       </h3>
@@ -38,3 +40,11 @@
 </div>
 
 <cvd-events-layout></cvd-events-layout>
+
+<cvd-help-tooltip>
+  <h3>Grafy</h3>
+
+  <p>
+    Graf nově nakažených. Můžete jej libovolně přibližovat a oddalovat. Zavedená opatření se na počtu nakažených projeví nejdříve po X dnech.
+  </p>
+</cvd-help-tooltip>

--- a/frontend/src/app/game/graphs/graphs.component.scss
+++ b/frontend/src/app/game/graphs/graphs.component.scss
@@ -3,17 +3,10 @@
 
 :host {
   @include panel;
-  position: relative;
 }
 
 cvd-line-graph {
   padding-top: 1.5rem;
-}
-
-h3 {
-  display: block;
-  margin: 1rem 0;
-  text-align: center;
 }
 
 .tabs {
@@ -45,5 +38,13 @@ h3 {
 
   cvd-icon {
     margin-right: 1rem;
+  }
+}
+
+.tab-content {
+  h3 {
+    display: block;
+    margin: 1rem 0;
+    text-align: center;
   }
 }

--- a/frontend/src/app/game/graphs/line-graph/line-graph.component.html
+++ b/frontend/src/app/game/graphs/line-graph/line-graph.component.html
@@ -1,22 +1,36 @@
 <cvd-col grow>
   <cvd-row grow justifyContent="flex-end" alignItems="center" style="width: 100%">
     <cvd-mitigation-scale [formControl]="scopeFormControl" [levels]="scaleLevels"></cvd-mitigation-scale>
+
     <div class="pan-arrows">
-      <button mat-icon-button (click)="pan.applyPan('left')" [disabled]="pan.getDisability('left')"
-              class="left-pan-arrow">
+      <button
+        mat-icon-button
+        (click)="pan.applyPan('left')"
+        [disabled]="pan.getDisability('left')"
+        matTooltip="Posunout vlevo"
+        class="left-pan-arrow">
         <mat-icon>chevron_left</mat-icon>
       </button>
-      <button mat-icon-button (click)="pan.applyPan('right')" [disabled]="pan.getDisability('right')">
+
+      <button
+        mat-icon-button
+        matTooltip="Posunout vpravo"
+        (click)="pan.applyPan('right')"
+        [disabled]="pan.getDisability('right')">
         <mat-icon>chevron_right</mat-icon>
       </button>
+
       <button [ngClass]="{'blinking': pan.autoResetIndicator}" mat-icon-button
+              matTooltip="Posunout na konec"
               (click)="pan.reset()" [disabled]="pan.getDisability('right')"
               class="right-pan-arrow">
         <mat-icon>last_page</mat-icon>
       </button>
+
       <div *ngIf="pan.autoResetIndicator" class="indicator"></div>
     </div>
   </cvd-row>
+
   <cvd-row style="width: 100%">
     <div class="chart">
       <div class="chart-inner">

--- a/frontend/src/app/game/mitigations-control/mitigations-control.component.html
+++ b/frontend/src/app/game/mitigations-control/mitigations-control.component.html
@@ -25,3 +25,44 @@
   </cvd-row>
 
 </cvd-col>
+
+<cvd-help-tooltip>
+  <h3>Opatření</h3>
+  <p>
+    Opatření jsou vaším hlavním prostředkem k ovlivňování šíření nákazy Covid-19.
+    <strong>Barva</strong> jsou aktivní opatření, <em>barva</em> naopak značí, že opatření aktuálně není zavedeno.
+    Každé opatření se projevuje na šíření koronaviru rozdílně.
+  </p>
+
+  <dl>
+    <dt>Roušky, ruce, rozestupy</dt>
+    <dd>
+      opatření, které není náročné na náklady a snižuje rychlost šíření infekce
+    </dd>
+
+    <dt>Uzavření hranic</dt>
+    <dd>
+      s výjimkou tranzitní dopravy a několika dalších výjimek se omezuje provoz přes hranice. Opatření snižuje rychlost šíření, ale negativně ovlivňuje náklady a společenskou stabilitu
+    </dd>
+
+    <dt>Omezení akcí</dt>
+    <dd>
+      opatření omezující maximální počet shromážděných lidí. Dopadá na kulturní či sportovní akce a různé oslavy. Negativně ovlivňuje náladu ve společnosti. Rušení akcí a zájezdů se promítá do nákladů zvládání pandemie
+    </dd>
+
+    <dt>Služby</dt>
+    <dd>
+      zavření rizikových provozů zahrnuje restaurace, bary, tělocvičny a podobné služby, kde je vysoké riziko přenosu. Dalším stupněm je pak uzavření všech obchodů a služeb, s výjimkou nezbytných (prodej potravin, paliv, apod.) Obě opatření do určité míry snižují rychlost šíření, ale negativně ovlivňují náklady a společenskou stabilitu
+    </dd>
+
+    <dt>Školy</dt>
+    <dd>
+      zvolte, které školy budou uzavřeny. Vysoké školy snadněji přechází na distanční výuku a náklady na jejich zavření jsou tak menší. Základní školy jsou významným místem setkávání a přenosu, ale jejich zavření silně negativně ovlivňuje náklady a společenskou stabilitu
+    </dd>
+
+    <dt>Zákaz vycházení</dt>
+    <dd>
+      mimo nákupy a cestu do práce je vycházení zásadně omezeno. Výrazně negativně ovlivňuje náladu ve společnosti, jeho udržování je pak velmi nákladné
+    </dd>
+  </dl>
+</cvd-help-tooltip>

--- a/frontend/src/app/shared/help-tooltip/help-tooltip.component.html
+++ b/frontend/src/app/shared/help-tooltip/help-tooltip.component.html
@@ -1,0 +1,21 @@
+<span
+  (click)="toggleState()"
+  [class.is-visible]="isVisible"
+  class="toggle-help-tooltip">
+  <cvd-icon>
+    {{ !isVisible ? 'help_outline' : 'close' }}
+  </cvd-icon>
+</span>
+
+<div
+  *ngIf="isVisible"
+  [@scaleAnimation]
+  class="content">
+</div>
+
+<div
+  *ngIf="isVisible"
+  class="content-text"
+  [@inOutAnimation]>
+  <ng-content></ng-content>
+</div>

--- a/frontend/src/app/shared/help-tooltip/help-tooltip.component.scss
+++ b/frontend/src/app/shared/help-tooltip/help-tooltip.component.scss
@@ -1,0 +1,107 @@
+@import '~src/definitions';
+
+$backgroundCard: map-get($theme, background);
+
+:host {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  z-index: 100;
+
+  pointer-events: none;
+
+  ::ng-deep {
+    h3 {
+      color: mat-color($theme-warn);
+    }
+  }
+}
+
+.toggle-help-tooltip {
+  position: absolute;
+  top: 0; left: 0;
+  z-index: 101;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+
+  pointer-events: auto;
+  cursor: pointer;
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0;
+    z-index: -1;
+
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 15px 15px 0 0;
+    border-color: mat-color($backgroundCard, card) transparent transparent transparent;
+    transition: border-color 300ms;
+
+    @media only screen and (min-width: 600px) {
+      border-width: 25px 25px 0 0;
+    }
+  }
+
+  cvd-icon {
+    color: mat-color($theme-primary);
+
+    transition: color 300ms;
+
+    ::ng-deep {
+      mat-icon {
+        width: 2rem;
+        height: 2rem;
+
+        font-size: 2rem;
+      }
+    }
+  }
+
+  &:hover {
+    &:before {
+      border-color: $dark-bg-lighter-30 transparent transparent transparent;
+    }
+
+    cvd-icon {
+      color: $light-primary-text;
+    }
+  }
+
+  &.is-visible {
+    &:before {
+      border-color: transparent;
+    }
+
+    &, &:hover {
+      cvd-icon {
+        color: $dark-primary-text;
+      }
+    }
+  }
+}
+
+.content {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+
+  @include cut-out-corners(false, true, true, true);
+  background: $light-bg-alpha-95;
+}
+
+.content-text {
+  position: absolute;
+  top: 25px; left: 0; right: 0; bottom: 25px;
+
+  padding: 2rem;
+  padding-top: 1rem;
+
+  overflow-y: auto;
+  color: $dark-primary-text;
+  pointer-events: auto;
+}

--- a/frontend/src/app/shared/help-tooltip/help-tooltip.component.scss
+++ b/frontend/src/app/shared/help-tooltip/help-tooltip.component.scss
@@ -21,11 +21,8 @@ $backgroundCard: map-get($theme, background);
   top: 0; left: 0;
   z-index: 101;
 
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 3.5rem;
+  height: 3.5rem;
 
   pointer-events: auto;
   cursor: pointer;
@@ -39,16 +36,20 @@ $backgroundCard: map-get($theme, background);
     width: 0;
     height: 0;
     border-style: solid;
-    border-width: 15px 15px 0 0;
+    pointer-events: none;
+    border-width: 2rem 2rem 0 0;
     border-color: mat-color($backgroundCard, card) transparent transparent transparent;
-    transition: border-color 300ms;
+    transition: border-width 300ms;
 
     @media only screen and (min-width: 600px) {
-      border-width: 25px 25px 0 0;
+      border-width: 3rem 3rem 0 0;
     }
   }
 
   cvd-icon {
+    position: relative;
+    top: 0.5rem; left: -0.25rem;
+
     color: mat-color($theme-primary);
 
     transition: color 300ms;
@@ -65,11 +66,8 @@ $backgroundCard: map-get($theme, background);
 
   &:hover {
     &:before {
-      border-color: $dark-bg-lighter-30 transparent transparent transparent;
-    }
-
-    cvd-icon {
-      color: $light-primary-text;
+      border-color: rgb(75, 119, 75) transparent transparent transparent;
+      border-width: 5rem 5rem 0 0;
     }
   }
 

--- a/frontend/src/app/shared/help-tooltip/help-tooltip.component.spec.ts
+++ b/frontend/src/app/shared/help-tooltip/help-tooltip.component.spec.ts
@@ -1,0 +1,26 @@
+/* tslint:disable:no-unused-variable */
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {HelpTooltipComponent} from './help-tooltip.component';
+
+describe('HelpTooltipComponent', () => {
+  let component: HelpTooltipComponent;
+  let fixture: ComponentFixture<HelpTooltipComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HelpTooltipComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HelpTooltipComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/shared/help-tooltip/help-tooltip.component.ts
+++ b/frontend/src/app/shared/help-tooltip/help-tooltip.component.ts
@@ -1,0 +1,24 @@
+import {Component, EventEmitter, Output} from '@angular/core';
+import {inOutAnimation, scaleAnimation} from 'src/app/utils/animations';
+
+@Component({
+  selector: 'cvd-help-tooltip',
+  templateUrl: './help-tooltip.component.html',
+  styleUrls: ['./help-tooltip.component.scss'],
+  animations: [
+    scaleAnimation,
+    inOutAnimation('400ms'),
+  ],
+})
+export class HelpTooltipComponent {
+  @Output()
+  changeCurrentState = new EventEmitter<boolean>();
+
+  isVisible = false;
+
+  toggleState() {
+    this.isVisible = !this.isVisible;
+
+    this.changeCurrentState.emit(this.isVisible);
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -14,9 +14,11 @@ import {IconComponent} from './icon/icon.component';
 import {initIconRegistry} from './icon/icon.registry';
 import {SharedMaterialModule} from './shared-material.module';
 import {FormatNumberPipe} from '../pipes/format-number.pipe';
+import {HelpTooltipComponent} from './help-tooltip/help-tooltip.component';
 
 const DECLARATIONS: Declaration[] = [
   ButtonComponent,
+  HelpTooltipComponent,
   FormatNumberPipe,
   FormatPercentagePipe,
   ColComponent,

--- a/frontend/src/app/utils/animations.ts
+++ b/frontend/src/app/utils/animations.ts
@@ -1,21 +1,50 @@
 import {trigger, transition, style, animate} from '@angular/animations';
 
-export const inOutAnimation = trigger(
-  'inOutAnimation',
+export const inOutAnimation = (delay = '0ms') => {
+  return trigger(
+    'inOutAnimation',
+    [
+      transition(
+        ':enter',
+        [
+          style({opacity: 0}),
+          animate(`300ms ${delay} ease-in` , style({opacity: 1})),
+        ],
+      ),
+      transition(
+        ':leave',
+        [
+          style({opacity: 1}),
+          animate(`100ms 0ms ease-in`, style({opacity: 0})),
+        ],
+      ),
+    ],
+  );
+};
+
+export const scaleAnimation = trigger(
+  'scaleAnimation',
   [
     transition(
       ':enter',
       [
-        style({opacity: 0}),
-        animate('300ms ease-in', style({opacity: 1})),
+        style({
+          transform: 'scale(0)',
+          transformOrigin: '0 0',
+        }),
+        animate('300ms cubic-bezier(.64,1.03,.26,.83)', style({transform: 'scale(1)'})),
       ],
     ),
     transition(
       ':leave',
       [
-        style({opacity: 1}),
-        animate('300ms ease-in', style({opacity: 0})),
+        style({
+          transform: 'scale(1)',
+          transformOrigin: '0 0',
+        }),
+        animate('300ms cubic-bezier(.64,1.03,.26,.83)', style({transform: 'scale(0)'})),
       ],
     ),
   ],
 );
+

--- a/frontend/src/definitions.scss
+++ b/frontend/src/definitions.scss
@@ -10,45 +10,71 @@
   display: flex;
 }
 
-@mixin cut-out-corners() {
+@function ternary($condition, $true-statement, $false-statement) {
+  $output: $false-statement;
+
+  @if ($condition) {
+    $output: $true-statement;
+  }
+
+  @return $output;
+}
+
+@mixin cut-out-corners(
+  $topLeft: true,
+  $topRight: true,
+  $bottomRight: true,
+  $bottomLeft: true,
+) {
   clip-path:
     polygon(
-        0% 15px,                 /* top left */
-        15px 0%,                 /* top left */
-        calc(100% - 15px) 0%,    /* top right */
-        100% 15px,               /* top right */
-        100% calc(100% - 15px),  /* bottom right */
-        calc(100% - 15px) 100%,  /* bottom right */
-        15px 100%,               /* bottom left */
-        0 calc(100% - 15px)      /* bottom left */
+        ternary($topLeft, 0% 15px, 0 0),                     /* top left */
+        ternary($topLeft, 15px 0%, 0 0),                     /* top left */
+        ternary($topRight, calc(100% - 15px) 0%, 0 0),       /* top right */
+        ternary($topRight, 100% 15px, 0 0),                  /* top right */
+        ternary($bottomRight, 100% calc(100% - 15px), 0 0),  /* bottom right */
+        ternary($bottomRight, calc(100% - 15px) 100%, 0 0),  /* bottom right */
+        ternary($bottomLeft, 15px 100%, 0 0),                /* bottom left */
+        ternary($bottomLeft, 0 calc(100% - 15px), 0 0),      /* bottom left */
     );
 
   @media only screen and (min-width: 600px) {
     clip-path:
       polygon(
-          0% 25px,                 /* top left */
-          25px 0%,                 /* top left */
-          calc(100% - 25px) 0%,    /* top right */
-          100% 25px,               /* top right */
-          100% calc(100% - 25px),  /* bottom right */
-          calc(100% - 25px) 100%,  /* bottom right */
-          25px 100%,               /* bottom left */
-          0 calc(100% - 25px)      /* bottom left */
+          ternary($topLeft, 0% 25px, 0 0),                     /* top left */
+          ternary($topLeft, 25px 0%, 0 0),                     /* top left */
+          ternary($topRight, calc(100% - 25px) 0%, 0 0),       /* top right */
+          ternary($topRight, 100% 25px, 0 0),                  /* top right */
+          ternary($bottomRight, 100% calc(100% - 25px), 0 0),  /* bottom right */
+          ternary($bottomRight, calc(100% - 25px) 100%, 0 0),  /* bottom right */
+          ternary($bottomLeft, 25px 100%, 0 0),                /* bottom left */
+          ternary($bottomLeft, 0 calc(100% - 25px), 0 0),      /* bottom left */
       );
   }
 }
 
 @mixin panel() {
+  position: relative;
+
   min-width: 5rem;
   min-height: 5rem;
   padding: 3rem;
 
   justify-content: center;
 
-  @include cut-out-corners;
 
-  @include apply-themes {
-    $background: map-get($theme, background);
-    background-color: mat-color($background, card);
+  &:after {
+    content: '';
+    position: absolute;
+    z-index: -1;
+    top: 0; left: 0; right: 0; bottom: 0;
+
+    @include cut-out-corners;
+
+    @include apply-themes {
+      $background: map-get($theme, background);
+      background-color: mat-color($background, card);
+    }
   }
+
 }

--- a/frontend/src/material-definitions.scss
+++ b/frontend/src/material-definitions.scss
@@ -122,6 +122,7 @@ $dark-bg-lighter-20:  lighten($dark-background, 20%);
 $dark-bg-lighter-30:  lighten($dark-background, 30%);
 $light-bg-alpha-4:    rgba(#fafafa, 0.04);
 $light-bg-alpha-12:   rgba(#fafafa, 0.12);
+$light-bg-alpha-95:   rgba(#fafafa, 0.95);
 
 // Background palette for dark themes.
 $mat-dark-theme-background: (

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -49,3 +49,11 @@ body {
     }
   }
 }
+
+dt {
+  font-weight: 600;
+}
+
+dd {
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
**To discuss:**

Icons, colors.

**preview:**

https://user-images.githubusercontent.com/4692060/104310186-9768ea00-54d3-11eb-985d-244b9756ba99.mov

**usage**
`cvd-help-tooltip` in panel blocks with transcluded content. State emitter also available (Pausing game for example, when the help is visible?)


update 

![image](https://user-images.githubusercontent.com/4692060/104321506-ff273100-54e3-11eb-8327-8da7b98af058.png)

