### PR TITLE
Add chosen mitigation of event with multiple choices to graph datalabels

### DIFF
--- a/frontend/src/app/game/events-layout/events-layout.component.html
+++ b/frontend/src/app/game/events-layout/events-layout.component.html
@@ -18,14 +18,14 @@
   <cvd-row grow>
     <cvd-button
       *ngFor="let choice of gameService.event.choices"
-      (click)="resumeEvent(choice)">
+      (click)="resumeEvent(gameService.event, choice)">
       {{choice.label}}
     </cvd-button>
 
     <cvd-button
       *ngIf="!gameService.event.choices?.length"
       cdkFocusInitial
-      (click)="resumeEvent()">
+      (click)="resumeEvent(gameService.event)">
       Ok
     </cvd-button>
   </cvd-row>

--- a/frontend/src/app/game/events-layout/events-layout.component.ts
+++ b/frontend/src/app/game/events-layout/events-layout.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {GameService} from '../game.service';
 import {UntilDestroy} from '@ngneat/until-destroy';
-import {EventChoice} from '../../services/events';
+import {Event, EventChoice} from '../../services/events';
 import {inOutAnimation} from 'src/app/utils/animations';
 
 @UntilDestroy()
@@ -15,12 +15,16 @@ export class EventsLayoutComponent {
   constructor(public gameService: GameService) {
   }
 
-  resumeEvent(choice?: EventChoice) {
+  resumeEvent(event: Event, choice?: EventChoice) {
     if (choice !== undefined) {
-      this.gameService.game.applyMitigationActions({
+     this.gameService.game.applyMitigationActions({
         eventMitigations: choice.mitigations,
         removeMitigationIds: choice.removeMitigationIds,
       });
+
+      if (event.choices && event.choices?.length > 1) {
+        this.gameService.activatedEvent = {originEvent: event, choice};
+      }
     }
 
     this.gameService.event = undefined;

--- a/frontend/src/app/game/game.service.ts
+++ b/frontend/src/app/game/game.service.ts
@@ -5,9 +5,12 @@ import {Event} from '../services/events';
 import {ReplaySubject, Subject} from 'rxjs';
 import {scenarios} from '../services/scenario';
 import {DayState} from '../services/simulation';
+import {UntilDestroy} from '@ngneat/until-destroy';
+import {ActivatedEvent} from './graphs/line-graph/line-graph.component';
 
 export type Speed = 'play' | 'pause' | 'fwd' | 'rev' | 'max' | 'finished';
 
+@UntilDestroy()
 @Injectable({
   providedIn: 'root',
 })
@@ -19,6 +22,7 @@ export class GameService {
   game!: Game;
   event: Event | undefined;
   tickerId: number | undefined;
+  activatedEvent: ActivatedEvent | undefined;
 
   private speed: Speed | undefined;
   private _speed$ = new Subject<Speed>();
@@ -110,6 +114,7 @@ export class GameService {
     this.showEvent(event);
 
     if (updateChart) this.updateChart();
+    this.activatedEvent = undefined;
   }
 
   private showEvent(event: Event | undefined) {

--- a/frontend/src/app/game/graphs/graphs.component.html
+++ b/frontend/src/app/game/graphs/graphs.component.html
@@ -22,7 +22,7 @@
 
       <cvd-line-graph
         *ngIf="!content.multiLineData$"
-        [mitigationNodes]="mitigationNodes"
+        [dataLabelNodes]="dataLabelNodes"
         [singleLineTick$]="content.data$"
         [scopeFormControl]="scopeFormControl"
         [customOptions]="content.customOptions">
@@ -30,7 +30,7 @@
 
       <cvd-line-graph
         *ngIf="content.multiLineData$"
-        [mitigationNodes]="mitigationNodes"
+        [dataLabelNodes]="dataLabelNodes"
         [multiLineTick$]="content.multiLineData$"
         [scopeFormControl]="scopeFormControl"
         [customOptions]="content.customOptions">

--- a/frontend/src/app/game/graphs/graphs.component.ts
+++ b/frontend/src/app/game/graphs/graphs.component.ts
@@ -8,7 +8,7 @@ import {filter, map} from 'rxjs/operators';
 import {formatNumber} from '../../utils/format';
 import {GameService} from '../game.service';
 import {MitigationsService} from '../mitigations-control/mitigations.service';
-import {ChartValue, colors, NodeState} from './line-graph/line-graph.component';
+import {ChartValue, colors, DataLabelNodes, NodeState} from './line-graph/line-graph.component';
 
 @UntilDestroy()
 @Component({
@@ -49,7 +49,7 @@ export class GraphsComponent implements AfterViewInit {
   immunized$: Observable<number> | undefined;
 
   mitigations$: Subscription | undefined;
-  mitigationNodes: (string | undefined)[] = [];
+  dataLabelNodes: DataLabelNodes[] = [];
   templateData: any | undefined;
   activeTab = 0;
 
@@ -89,7 +89,11 @@ export class GraphsComponent implements AfterViewInit {
       untilDestroyed(this),
       map(d => d.length),
     ).subscribe(length => {
-      this.mitigationNodes[length - 1] = this.currentMitigation;
+      this.dataLabelNodes[length - 1] = {event: undefined, mitigations: this.currentMitigation};
+      if (this.gameService.activatedEvent) {
+        this.dataLabelNodes[length - 1].event = this.gameService.activatedEvent;
+      }
+
       this.currentMitigation = undefined;
     });
 
@@ -197,7 +201,7 @@ export class GraphsComponent implements AfterViewInit {
       untilDestroyed(this),
     ).subscribe(() => {
       this.currentMitigation = undefined;
-      this.mitigationNodes = [];
+      this.dataLabelNodes = [];
     });
 
     // TODO connect to change-only mitigation structure


### PR DESCRIPTION
<img width="746" alt="Screen Shot 2021-01-13 at 4 14 33 PM" src="https://user-images.githubusercontent.com/11981022/104470851-4578af00-560e-11eb-8e7d-1bfd7918c42a.png">

In case I set mitigations while event overlay is active then in graph is shown only Event-like datalabel with details in tooltip.
<img width="746" alt="Screen Shot 2021-01-13 at 4 14 30 PM" src="https://user-images.githubusercontent.com/11981022/104470861-47db0900-560e-11eb-8248-a48daad679b8.png">
