### PR TITLE
Per event condition

### DIFF
--- a/frontend/src/app/services/event-list.ts
+++ b/frontend/src/app/services/event-list.ts
@@ -81,12 +81,14 @@ export interface EventData {
   minStability: number;
 }
 
-export const initialEventData: EventData = {
-  aboveSelfIsolationThresholdDays: 0,
-  belowSelfIsolationThresholdDays: 0,
-  showAntivaxEvent: false,
-  minStability: 100,
-};
+export function initialEventData(): EventData {
+  return {
+    aboveSelfIsolationThresholdDays: 0,
+    belowSelfIsolationThresholdDays: 0,
+    showAntivaxEvent: false,
+    minStability: 100,
+  };
+}
 
 /**
  * Callback that is called every day before trigger conditions are evaluated

--- a/frontend/src/app/services/events.ts
+++ b/frontend/src/app/services/events.ts
@@ -67,8 +67,10 @@ export class EventHandler {
     mitigations: Mitigations, eventMitigations: EventMitigation[]) {
     let prevState = this.eventStateHistory[prevDate];
     if (!prevState) {
-      const initialTriggerStates = eventTriggers.map(et => ({trigger: et}));
-      prevState = {triggerStates: initialTriggerStates, eventData: initialEventData};
+      prevState = {
+        triggerStates: eventTriggers.map(et => ({trigger: et})),
+        eventData: initialEventData(),
+      };
     }
 
     const triggerStates = prevState.triggerStates.map(ts => ({...ts,

--- a/frontend/src/app/services/events.ts
+++ b/frontend/src/app/services/events.ts
@@ -27,12 +27,14 @@ export interface Event {
   choices?: EventChoice[];
 }
 
-type EventText = ((stats: EventInput) => string) | string;
+type EventText = ((eventInput: EventInput) => string) | string;
+type EventCondition = (eventInput: EventInput) => boolean;
 
 interface EventDef {
   title: EventText;
   text?: EventText;
   help?: EventText;
+  condition?: EventCondition;
   choices?: EventChoiceDef[];
 }
 
@@ -40,7 +42,7 @@ export interface EventTrigger {
   id?: string;
   events: EventDef[];
   reactivateAfter?: number;
-  condition: (stats: EventInput) => boolean;
+  condition: EventCondition;
 }
 
 interface TriggerState {
@@ -99,7 +101,11 @@ export class EventHandler {
     triggered.forEach(ts => ts.activeBefore = 0);
 
     // Needs explicit cast because sample returns EventDef | undefined
-    const eventDefs = triggered.map(ts => sample(ts.trigger.events)).filter(e => e) as EventDef[];
+    const eventDefs = triggered.map(ts => {
+      const activeEvents = ts.trigger.events.filter(e => !e.condition || e.condition(eventInput));
+      return sample(activeEvents);
+      // Needs explicit cast because the compiler doesn't know we filter out undefined elements
+    }).filter(e => e) as EventDef[];
 
     // safeguard for empty event list
     if (eventDefs.length === 0) return;


### PR DESCRIPTION
Two patches
- generate EventData on each restart: useful for per game randomization
- Per event condition: simplifies antivax a lot, also do show event related to not wearing face masks if the face masks are not obligatory