### PR TITLE
Feature/backend store load

### DIFF
--- a/frontend/src/app/game/game-material.module.ts
+++ b/frontend/src/app/game/game-material.module.ts
@@ -3,6 +3,7 @@ import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {MatChipsModule} from '@angular/material/chips';
 import {MatDividerModule} from '@angular/material/divider';
 import {MatRippleModule} from '@angular/material/core';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {MatSliderModule} from '@angular/material/slider';
 import {MatTabsModule} from '@angular/material/tabs';
@@ -15,11 +16,12 @@ import {A11yModule} from '@angular/cdk/a11y';
     MatButtonToggleModule,
     MatChipsModule,
     MatDividerModule,
+    MatProgressSpinnerModule,
+    MatRippleModule,
     MatSliderModule,
     MatSlideToggleModule,
     MatTabsModule,
     MatTooltipModule,
-    MatRippleModule,
   ],
 })
 export class GameMaterialModule {

--- a/frontend/src/app/game/game.service.ts
+++ b/frontend/src/app/game/game.service.ts
@@ -160,7 +160,7 @@ export class GameService {
     this.saveCheckpoint();
     const gameData = this.getGameData();
     return this.httpClient.post<{id: string}>('/api/game-data', gameData).pipe(
-      tap((data: any) => this.saveGameId(data.id)),
+      tap(data => this.saveGameId(data.id)),
     );
   }
 
@@ -179,24 +179,27 @@ export class GameService {
   }
 
   private loadGameFromJson() {
-    this.setSpeed('pause');
     const dataString = window.localStorage.getItem(LocalStorageKey.LAST_GAME_DATA);
     if (!dataString) return false;
 
     try {
       const game = validateGame(JSON.parse(dataString));
       if (!game) return false;
-
-      this.game = game;
-      this.game.scenario.dates.endDate = scenarios.czechiaGame.dates.endDate;
-      this._reset$.next();
+      this.restoreGame(game);
       this.setSpeed('play');
-      this.updateChart();
     } catch {
       return false;
     }
 
     return true;
+  }
+
+  restoreGame(game: Game) {
+    this.setSpeed('pause');
+    this.game = game;
+    this.game.scenario.dates.endDate = scenarios.czechiaGame.dates.endDate;
+    this._reset$.next();
+    this.updateChart();
   }
 
   private scheduleTick(interval?: number) {

--- a/frontend/src/app/game/game.service.ts
+++ b/frontend/src/app/game/game.service.ts
@@ -1,15 +1,15 @@
-import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
-import {Game, GameData} from '../services/game';
-import {Event} from '../services/events';
-import {ReplaySubject, Subject} from 'rxjs';
-import {scenarios} from '../services/scenario';
-import {DayState} from '../services/simulation';
+import {Injectable} from '@angular/core';
 import {UntilDestroy} from '@ngneat/until-destroy';
 import {meanBy} from 'lodash';
-import {LocalStorageKey} from '../../environments/defaults';
-import {validateGame} from '../services/validate';
+import {ReplaySubject, Subject} from 'rxjs';
 import {tap} from 'rxjs/operators';
+import {LocalStorageKey} from '../../environments/defaults';
+import {Event} from '../services/events';
+import {Game, GameData} from '../services/game';
+import {scenarios} from '../services/scenario';
+import {DayState} from '../services/simulation';
+import {validateGame} from '../services/validate';
 
 export type Speed = 'auto' | 'rev' | 'pause' | 'slow' | 'play' | 'fast' | 'max' | 'finished';
 
@@ -159,7 +159,7 @@ export class GameService {
   save$() {
     this.saveCheckpoint();
     const gameData = this.getGameData();
-    return this.httpClient.post('/api/game-data', gameData).pipe(
+    return this.httpClient.post<{id: string}>('/api/game-data', gameData).pipe(
       tap((data: any) => this.saveGameId(data.id)),
     );
   }

--- a/frontend/src/app/game/pages/about/about.component.html
+++ b/frontend/src/app/game/pages/about/about.component.html
@@ -1,6 +1,9 @@
 <cvd-col>
   <h2>About</h2>
 
+  <a routerLink="/results/123456">123456</a>
+  <a routerLink="/results/098765">098765</a>
+
   <cvd-button cvdNavigateBack>
     <cvd-icon>undo</cvd-icon>
     Zpět

--- a/frontend/src/app/game/pages/about/about.component.spec.ts
+++ b/frontend/src/app/game/pages/about/about.component.spec.ts
@@ -1,4 +1,5 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
 import {GameModule} from '../../game.module';
 import {AboutComponent} from './about.component';
 
@@ -9,6 +10,7 @@ describe('AboutComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
+        RouterTestingModule,
         GameModule,
       ],
     })

--- a/frontend/src/app/game/pages/game/game.component.ts
+++ b/frontend/src/app/game/pages/game/game.component.ts
@@ -1,7 +1,7 @@
 import {Component, HostBinding} from '@angular/core';
 import {Router} from '@angular/router';
 import {UntilDestroy, untilDestroyed} from '@ngneat/until-destroy';
-import {filter, map, switchMap} from 'rxjs/operators';
+import {filter, switchMap} from 'rxjs/operators';
 import {DebugModeService} from 'src/app/services/debug-mode.service';
 import {MetaService} from 'src/app/services/meta.service';
 import {inOutAnimation} from 'src/app/utils/animations';
@@ -19,7 +19,7 @@ export class GameComponent {
 
   constructor(
     public debugModeService: DebugModeService,
-    outroService: OutroService,
+    private outroService: OutroService,
     private gameService: GameService,
     private router: Router,
     meta: MetaService,
@@ -29,24 +29,10 @@ export class GameComponent {
     // fetch historical game results from BE
     window.setTimeout(() => outroService.fetchAllResults(), 10_000);
 
-    // send current game result into outro
-    gameService.gameState$.pipe(
-      filter(states => states.length > 0),
-      map(states => states[states.length - 1]),
-      map(state => ({
-        dead: state.stats.deaths.total,
-        cost: state.stats.costs.total,
-      })),
-      untilDestroyed(this),
-    ).subscribe(
-      result => outroService.setMyResult(result),
-    );
-
     // trigger end of game
     gameService.speed$.pipe(
       filter(speed => speed === 'finished'),
-      switchMap(() => this.gameService.save$()),
-      map(response => response.id),
+      switchMap(() => this.outroService.saveGame$()),
       untilDestroyed(this),
     ).subscribe(
       id => this.router.navigate([`/results/${id}`]),

--- a/frontend/src/app/game/pages/game/game.component.ts
+++ b/frontend/src/app/game/pages/game/game.component.ts
@@ -46,9 +46,10 @@ export class GameComponent {
     gameService.speed$.pipe(
       filter(speed => speed === 'finished'),
       switchMap(() => this.gameService.save$()),
+      map(response => response.id),
       untilDestroyed(this),
     ).subscribe(
-      id => this.router.navigate(['/results', id]),
+      id => this.router.navigate([`/results/${id}`]),
       () => this.router.navigate(['/results']),
     );
   }

--- a/frontend/src/app/game/pages/outro/outro.component.html
+++ b/frontend/src/app/game/pages/outro/outro.component.html
@@ -16,7 +16,8 @@
     [options]="outroChartOptions" [datasets]="(datasets$ | async)!"
   ></cvd-scatter-graph>
 
-  <cvd-graphs style="width: 90%"></cvd-graphs>
+  <cvd-graphs *ngIf="isGameReady$ | async" style="width: 90%"></cvd-graphs>
+  <mat-spinner *ngIf="!(isGameReady$ | async)" style="margin:auto"></mat-spinner>
 
   <div class="content">
     <ng-content></ng-content>

--- a/frontend/src/app/game/pages/outro/outro.component.ts
+++ b/frontend/src/app/game/pages/outro/outro.component.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 import {UntilDestroy} from '@ngneat/until-destroy';
 import {ChartDataSets, ChartOptions, ChartPoint, ScaleTitleOptions} from 'chart.js';
 import {combineLatest, Observable} from 'rxjs';
@@ -25,6 +26,8 @@ const convert: (result: GameResult) => ChartPoint =
   styleUrls: ['./outro.component.scss'],
 })
 export class OutroComponent {
+
+  resultId$: Observable<string>;
 
   private readonly scalesLabelsDefaults: ScaleTitleOptions = {
     display: true,
@@ -126,7 +129,9 @@ export class OutroComponent {
     public gameService: GameService,
     meta: MetaService,
     public shareService: SocialNetworkShareService,
+    activatedRoute: ActivatedRoute,
   ) {
+    this.resultId$ = activatedRoute.params.pipe(map(data => data.id));
     meta.setTitle('Výsledky');
     outroService.fetchAllResults();
   }

--- a/frontend/src/app/game/pages/outro/outro.service.ts
+++ b/frontend/src/app/game/pages/outro/outro.service.ts
@@ -1,7 +1,7 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {UntilDestroy, untilDestroyed} from '@ngneat/until-destroy';
-import {BehaviorSubject, Observable, Subject} from 'rxjs';
+import {BehaviorSubject, Observable, of, Subject} from 'rxjs';
 import {filter, map, shareReplay, switchMap, tap} from 'rxjs/operators';
 import {GameData} from '../../../services/game';
 import {validateGame} from '../../../services/validate';
@@ -89,11 +89,14 @@ export class OutroService {
   }
 
   saveGame$() {
+    const {id} = this._current$.value;
+    if (id) return of(id);
+
     return this.gameService.save$().pipe(
       map(response => response.id),
-      tap(id => {
+      tap(newId => {
         const current = this._current$.value;
-        this._current$.next({...current, id});
+        this._current$.next({...current, id: newId});
       }),
     );
   }

--- a/frontend/src/app/game/pages/outro/outro.service.ts
+++ b/frontend/src/app/game/pages/outro/outro.service.ts
@@ -2,11 +2,26 @@ import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {UntilDestroy, untilDestroyed} from '@ngneat/until-destroy';
 import {BehaviorSubject, Observable, Subject} from 'rxjs';
-import {shareReplay, switchMap} from 'rxjs/operators';
+import {filter, map, shareReplay, switchMap, tap} from 'rxjs/operators';
+import {GameData} from '../../../services/game';
+import {validateGame} from '../../../services/validate';
+import {GameService} from '../../game.service';
 
 export interface GameResult {
   dead: number;
   cost: number;
+}
+
+interface Current {
+  id?: string;
+  result?: GameResult;
+  gameIsReady: boolean;
+}
+
+interface GameDataResponse extends GameData {
+  _id: string;
+  created: string;
+  results: GameResult;
 }
 
 @UntilDestroy()
@@ -15,16 +30,30 @@ export interface GameResult {
 })
 export class OutroService {
 
-  private _myResult$ = new BehaviorSubject<GameResult | undefined>(undefined);
+  private _current$ = new BehaviorSubject<Current>({gameIsReady: true});
+  current$ = this._current$.asObservable();
 
-  myResult$ = this._myResult$.asObservable();
   allResults$: Observable<GameResult[]>;
 
   private fetch$ = new Subject();
 
   constructor(
     private httpClient: HttpClient,
+    private gameService: GameService,
   ) {
+    // send current game result into outro
+    gameService.gameState$.pipe(
+      filter(states => states.length > 0),
+      map(states => states[states.length - 1]),
+      map(state => ({
+        dead: state.stats.deaths.total,
+        cost: state.stats.costs.total,
+      })),
+      untilDestroyed(this),
+    ).subscribe(
+      result => this._current$.next({result, gameIsReady: true}),
+    );
+
     this.allResults$ = this.fetch$.pipe(
       switchMap(() => this.httpClient.get<GameResult[]>('/api/game-data')),
       shareReplay(1),
@@ -34,11 +63,38 @@ export class OutroService {
     this.allResults$.subscribe();
   }
 
-  setMyResult(result: GameResult) {
-    this._myResult$.next(result);
-  }
-
   fetchAllResults() {
     this.fetch$.next();
+  }
+
+  loadGame(id: string) {
+    if (id === this._current$.value.id) return;
+
+    this._current$.next({id, gameIsReady: false});
+
+    this.httpClient.get<GameDataResponse>(`/api/game-data/${id}`).subscribe(
+      response => {
+        if (!response) return;
+
+        const {_id, created, results, ...gameData} = response;
+        this._current$.next({id, gameIsReady: false, result: results});
+
+        const game = validateGame(gameData);
+        if (!game) return;
+
+        this.gameService.restoreGame(game);
+        this._current$.next({id, gameIsReady: true, result: results});
+      },
+    );
+  }
+
+  saveGame$() {
+    return this.gameService.save$().pipe(
+      map(response => response.id),
+      tap(id => {
+        const current = this._current$.value;
+        this._current$.next({...current, id});
+      }),
+    );
   }
 }


### PR DESCRIPTION
- ongoing results during the game,
- save finished game before navigate to outro page (get game ID and render result URL)
- load game data from BE and restore game when outro page is loaded directly from URL with game ID
- supports NG routing (we can use routerLink="/results/600608f6550d04116370393d to show results)
- dont save previously saved game, dont load current game from BE