### PR TITLE
Speed up and load balance API requests

### DIFF
--- a/backend/src/game/model.ts
+++ b/backend/src/game/model.ts
@@ -22,14 +22,18 @@ const GameDataSchema = new Schema({
     required: true
   },
   results: {
-    dead: {
-      type: Number,
-      required: true,
+    type: {
+      dead: {
+        type: Number,
+        required: true,
+      },
+      cost: {
+        type: Number,
+        required: true,
+      },
     },
-    cost: {
-      type: Number,
-      required: true,
-    },
+    required: true,
+    index: true,
   },
   created: {
     type: Date,

--- a/backend/src/game/routes.ts
+++ b/backend/src/game/routes.ts
@@ -10,7 +10,9 @@ import {formatNumber} from '../../../frontend/src/app/utils/format';
 export const router = new Router<DefaultState, Context>();
 
 router.get('/api/game-data', async (ctx) => {
-  const data = await GameDataModel.find({}, {results: 1});
+  const data = await GameDataModel
+    .find({}, {results: 1, _id: 0})
+    .hint('results_1')
   ctx.body = data.map((i: any) => i.results);
 });
 

--- a/build/ansible/environments/dev/group_vars/all.yml
+++ b/build/ansible/environments/dev/group_vars/all.yml
@@ -1,5 +1,6 @@
 env: dev
 url: korona.swehq.com
 admin_email: admin@swehq.com
+backend_container_count: 4
 
 www_redirection: false

--- a/build/ansible/environments/prod/group_vars/all.yml
+++ b/build/ansible/environments/prod/group_vars/all.yml
@@ -1,5 +1,6 @@
 env: prod
 url: koronahra.cz
 admin_email: admin@koronahra.cz
+backend_container_count: 4
 
 www_redirection: true

--- a/build/ansible/roles/nginx/templates/nginx.conf
+++ b/build/ansible/roles/nginx/templates/nginx.conf
@@ -21,3 +21,11 @@ server {
     return 301 https://{{ url }}$request_uri;
 }
 {% endif %}
+
+gzip on;
+gzip_http_version 1.1;
+gzip_disable "MSIE [1-6]\.";
+gzip_min_length 1100;
+gzip_vary on;
+gzip_proxied expired no-cache no-store private auth;
+gzip_comp_level 9;

--- a/build/ansible/roles/run/tasks/main.yml
+++ b/build/ansible/roles/run/tasks/main.yml
@@ -5,6 +5,6 @@
   shell: docker-compose {{item}}
   with_items:
     - pull
-    - up -d
+    - up -d --remove-orphans
   args:
     chdir: "{{ deploy_dir }}"

--- a/build/ansible/shared/templates/docker-compose.be.deploy.yml
+++ b/build/ansible/shared/templates/docker-compose.be.deploy.yml
@@ -6,15 +6,23 @@ networks:
       name: nginx
 
 services:
-  backend:
-    container_name: "{{ backend_container }}"
+{% if backend_container_count is not defined %}
+{% set backend_container_count = 1 %}
+{% endif %}
+{% for counter in range(1, backend_container_count + 1) %}
+  backend-{{ counter }}:
+    hostname: "{{ backend_container }}"
+    container_name: "{{ backend_container }}-{{ counter }}"
     image: "{{ backend_remote_image_latest }}"
     restart: unless-stopped
     networks:
-      - nginx
-      - "{{ base_name }}-{{ env }}"
+      nginx:
+        aliases:
+          - "{{ backend_container }}"
+      "{{ base_name }}-{{ env }}":
     environment:
       PORT: 80
       MONGO_URI: mongodb://mongo/corona
     expose:
       - 80
+{% endfor %}


### PR DESCRIPTION
- mongo uses index for more effective results projection
- nginx gzip compresses even api communication
- start several BE containers and use round-robin DNS
  from nginx via shared hostname
  (nginx-proxy is not ready for simple setting of
  several upstream servers)
